### PR TITLE
Organizing berdi/Section_03

### DIFF
--- a/berdi/Section_03_Table_and_Figure_Title_Extraction/constants.py
+++ b/berdi/Section_03_Table_and_Figure_Title_Extraction/constants.py
@@ -2,14 +2,16 @@ import re
 from pathlib import Path
 
 # paths to data
-main_path = r"//luxor/data/branch/Environmental Baseline Data/Version 4 - Final/"
-projects_path = Path(
-    main_path + r"Indices/Index 2 - PDFs for Major Projects with ESAs.xlsx"
-)
-pickles_path = main_path + "Pickles/"
-pickles_rotated_path = main_path + "Pickles_rotated/"
-csv_path = main_path + "CSV_final/"
-save_dir = main_path + "Saved2/"
+ROOT_PATH = Path(__file__).parents[1].resolve()
+RAW_DATA_PATH = ROOT_PATH / "data" / "raw"
+INDEX_PATH = RAW_DATA_PATH / "index_for_projects"
+PROCESSED_DATA_PATH = ROOT_PATH / "data" / "processed"
+
+projects_path = str(INDEX_PATH / "Index 2 - PDFs for Major Projects with ESAs.xlsx")
+pickles_path = str(PROCESSED_DATA_PATH / "pickle_files")
+pickles_rotated_path = str(PROCESSED_DATA_PATH / "pickle_files_rotated")
+csv_path = str(PROCESSED_DATA_PATH / "csvs" / "all_csvs")
+save_dir = str(ROOT_PATH / "data" / "output")
 
 # regexes
 empty_line_xml = re.compile(r"<\/p>\s*<p ?\/?>")

--- a/berdi/Section_03_Table_and_Figure_Title_Extraction/constants.py
+++ b/berdi/Section_03_Table_and_Figure_Title_Extraction/constants.py
@@ -2,33 +2,51 @@ import re
 from pathlib import Path
 
 # paths to data
-main_path = r'//luxor/data/branch/Environmental Baseline Data/Version 4 - Final/'
-projects_path = Path(main_path + r'Indices/Index 2 - PDFs for Major Projects with ESAs.xlsx')
-pickles_path = main_path + 'Pickles/'
-pickles_rotated_path = main_path + 'Pickles_rotated/'
-csv_path = main_path + 'CSV_final/'
-save_dir = main_path + 'Saved2/'
+main_path = r"//luxor/data/branch/Environmental Baseline Data/Version 4 - Final/"
+projects_path = Path(
+    main_path + r"Indices/Index 2 - PDFs for Major Projects with ESAs.xlsx"
+)
+pickles_path = main_path + "Pickles/"
+pickles_rotated_path = main_path + "Pickles_rotated/"
+csv_path = main_path + "CSV_final/"
+save_dir = main_path + "Saved2/"
 
 # regexes
-empty_line_xml = re.compile(r'<\/p>\s*<p ?\/?>')
-empty_line = re.compile(r'^\s*$')
-whitespace = re.compile(r'\s+')  # all white space
-punctuation = re.compile(r'[^\w\s]')  # punctuation (not letter or number)
-# figure = re.compile(r'(?im)(^Figure .*?\n?.*?)\.{2,}(.*)')
-# table = re.compile(r'(?im)(^Table (?!of contents?).*?\n?.*?)\.{2,}(.*)')
-toc_old = re.compile(r'(?im)^(?! *LIST OF\b)(?! *Table of contents\b)(.+?\n?.*?)\.{2,}(.*)$')
-toc = re.compile(r'(?im)^(?! *LIST OF\b)(?! *Table of contents\b)(.+?\n?.*?\n?.*?)\.{2,}(.*)$')
-accepted_toc = ['Figure', 'Table', 'Plate', 'Attachment', 'Detail', 'Drawing', 'Photograph', 'Photo',
-                'Sheet', 'Tableau', 'Index', 'Overview']
+empty_line_xml = re.compile(r"<\/p>\s*<p ?\/?>")
+empty_line = re.compile(r"^\s*$")
+whitespace = re.compile(r"\s+")  # all white space
+punctuation = re.compile(r"[^\w\s]")  # punctuation (not letter or number)
+figure = re.compile(r"(?im)(^Figure .*?\n?.*?)\.{2,}(.*)")
+table = re.compile(r"(?im)(^Table (?!of contents?).*?\n?.*?)\.{2,}(.*)")
+toc_old = re.compile(
+    r"(?im)^(?! *LIST OF\b)(?! *Table of contents\b)(.+?\n?.*?)\.{2,}(.*)$"
+)
+toc = re.compile(
+    r"(?im)^(?! *LIST OF\b)(?! *Table of contents\b)(.+?\n?.*?\n?.*?)\.{2,}(.*)$"
+)
+accepted_toc = [
+    "Figure",
+    "Table",
+    "Plate",
+    "Attachment",
+    "Detail",
+    "Drawing",
+    "Photograph",
+    "Photo",
+    "Sheet",
+    "Tableau",
+    "Index",
+    "Overview",
+]
 
-figures_rex = re.compile(r'.*\bF[iI][gG][uU][rR][eE][sS]?\b')
-tables_rex = re.compile(r'^T[aA][bB][lL][eE][sS]?\b')
-small_word = re.compile(r'\b[a-zA-Z]{1,2}\b') # words that are 1 or 2 letters (no numbers or punctuation)
-# cont_rex = re.compile(r'')
-# extra_chars = re.compile(r'-|:|-|\(|\.') # extra characters we want to delete from string
+figures_rex = re.compile(r".*\bF[iI][gG][uU][rR][eE][sS]?\b")
+tables_rex = re.compile(r"^T[aA][bB][lL][eE][sS]?\b")
+small_word = re.compile(
+    r"\b[a-zA-Z]{1,2}\b"
+)  # words that are 1 or 2 letters (no numbers or punctuation)
+cont_rex = re.compile(r"")
+extra_chars = re.compile(
+    r"-|:|-|\(|\."
+)  # extra characters we want to delete from string
 
-exceptions_list = ['...', 'table of content', 'table des matières']
-
-
-
-
+exceptions_list = ["...", "table of content", "table des matières"]

--- a/berdi/Section_03_Table_and_Figure_Title_Extraction/external_functions.py
+++ b/berdi/Section_03_Table_and_Figure_Title_Extraction/external_functions.py
@@ -1,3 +1,4 @@
+from dotenv import load_dotenv
 import pandas as pd
 import re
 import regex
@@ -11,10 +12,14 @@ from fuzzywuzzy import fuzz
 import json
 import numpy as np
 
-from Codes.Database_Connection_Files.connect_to_database import connect_to_db
-import Codes.Section_03_Table_and_Figure_Title_Extraction.constants as constants
+from berdi.Database_Connection_Files.connect_to_database import connect_to_db
+import berdi.Section_03_Table_and_Figure_Title_Extraction.constants as constants
 
 
+# Load environment variables (from .env file) for the database
+load_dotenv(
+    dotenv_path=constants.ROOT_PATH / "berdi/Database_Connection_Files" / ".env", override=True
+)
 engine = connect_to_db()
 
 


### PR DESCRIPTION
## What?
I'm trying to make berdi match the following template as much as possible: https://github.com/drivendata/cookiecutter-data-science

For this PR, I mostly worked on `berdi.Section_03`. I changed very little, mostly the filepaths.

What I did:

- Fixed the filepaths in `Section_02` to fit the new structure of the repository. Removed unnecessary environment variables for filepaths. Used `Path` instead to make it easier to use the code right away.
- Cleaned up the code by removing commented code and reorganized some code.

## Why?
I'm trying to standardize the codebase in a way that fits with best practices. I changed a few of the directory names. 

## Anything Else?
As with the previous section, I have not fully tested the code yet.